### PR TITLE
Fix for repeated world loads and outdated references

### DIFF
--- a/src/Gantry.Core/ApiEx.cs
+++ b/src/Gantry.Core/ApiEx.cs
@@ -31,11 +31,11 @@ namespace Gantry.Core
         {
             switch (api.Side)
             {
-                case EnumAppSide.Server:
-                    Server ??= api as ICoreServerAPI;
-                    break;
-                case EnumAppSide.Client:
-                    Client ??= api as ICoreClientAPI;
+                case EnumAppSide.Server: 
+                    Server = api as ICoreServerAPI;                    
+                    break;                        
+                case EnumAppSide.Client:                       
+                    Client = api as ICoreClientAPI;
                     break;
                 case EnumAppSide.Universal:
                 default:
@@ -53,14 +53,23 @@ namespace Gantry.Core
         ///     Contains all sub-components, and some miscellaneous methods.
         /// </summary>
         /// <value>The client-side API.</value>
-        public static ICoreClientAPI Client { get; private set; }
+        public static ICoreClientAPI Client {
+            get => _clients.FirstOrDefault(); 
+            private set => _clients.Push(value);
+        }
 
         /// <summary>
         ///     The core API implemented by the server.<br/>
         ///     The main interface for accessing the server.<br/>
         ///     Contains all sub-components, and some miscellaneous methods.
         /// </summary>
-        public static ICoreServerAPI Server { get; private set; }
+        public static ICoreServerAPI Server { 
+            get => _servers.FirstOrDefault();
+            private set => _servers.Push(value); 
+        }
+
+        private static Stack<ICoreServerAPI> _servers = new();
+        private static Stack<ICoreClientAPI> _clients = new();
 
         /// <summary>
         ///     Common API Components that are available on the server and the client.<br/>


### PR DESCRIPTION
This is my quick & dirty fix for ApacheTech-VintageStory-Mods/ApacheTech.VintageMods.CampaignCartographer#34

With this change CampaignCartographer correctly loads for non initial worlds, UI works as expected and commands work. 

I've chosen a stack for each client & server side because there _may_ be a reason to actually keep track of running things as well as potentially remove them on shutdown. But I'm not familiar enough with VS extension hooks to pinpoints where to trigger _that_, so it's just... not there ;)

And yes, this may leak things if people enter dozens of worlds during a single application run. Heck, functionally a simple field would do, but the stack allows things like `First`, `Last`, etc.

And it works 🎉 